### PR TITLE
Fix Race Conditions (Linux)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ bin-freebsd: build/freebsd-amd64/nebula build/freebsd-amd64/nebula-cert
 	mv $? .
 
 bin:
-	go build -trimpath -ldflags "$(LDFLAGS)" -o ./nebula ${NEBULA_CMD_PATH}
-	go build -trimpath -ldflags "$(LDFLAGS)" -o ./nebula-cert ./cmd/nebula-cert
+	go build $(GOFLAGS) -trimpath -ldflags "$(LDFLAGS)" -o ./nebula ${NEBULA_CMD_PATH}
+	go build $(GOFLAGS) -trimpath -ldflags "$(LDFLAGS)" -o ./nebula-cert ./cmd/nebula-cert
 
 install:
 	go install -trimpath -ldflags "$(LDFLAGS)" ${NEBULA_CMD_PATH}

--- a/connection_state.go
+++ b/connection_state.go
@@ -21,7 +21,7 @@ type ConnectionState struct {
 	messageCounter *uint64
 	window         *Bits
 	queueLock      sync.Mutex
-	lock           sync.RWMutex
+	mx             sync.RWMutex
 	ready          bool
 }
 
@@ -72,4 +72,11 @@ func (cs *ConnectionState) MarshalJSON() ([]byte, error) {
 		"message_counter": cs.messageCounter,
 		"ready":           cs.ready,
 	})
+}
+
+func (cs *ConnectionState) IsReady() bool {
+	if cs != nil && cs.eKey != nil && cs.ready {
+		return true
+	}
+	return false
 }

--- a/connection_state.go
+++ b/connection_state.go
@@ -74,6 +74,9 @@ func (cs *ConnectionState) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// IsReady allows checking if the connection is in a ready state
+// caller must take care to lock connection state, and any
+// wrapping data types accordingly
 func (cs *ConnectionState) IsReady() bool {
 	if cs != nil && cs.eKey != nil && cs.ready {
 		return true

--- a/connection_state.go
+++ b/connection_state.go
@@ -21,8 +21,8 @@ type ConnectionState struct {
 	messageCounter *uint64
 	window         *Bits
 	queueLock      sync.Mutex
-	// writeLock      sync.Mutex
-	ready bool
+	lock           sync.RWMutex
+	ready          bool
 }
 
 func (f *Interface) newConnectionState(initiator bool, pattern noise.HandshakePattern, psk []byte, pskStage int) *ConnectionState {

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -337,11 +337,11 @@ func ixHandshakeStage2(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 	// and complete standing up the connection.
 	if dKey != nil && eKey != nil {
 		ip := ip2int(remoteCert.Details.Ips[0].IP)
-		ci.lock.Lock()
+		ci.mx.Lock()
 		ci.peerCert = remoteCert
 		ci.dKey = NewNebulaCipherState(dKey)
 		ci.eKey = NewNebulaCipherState(eKey)
-		ci.lock.Unlock()
+		ci.mx.Unlock()
 		//l.Debugln("got symmetric pairs")
 
 		//hostinfo.ClearRemotes()

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -109,8 +109,8 @@ func (c *HandshakeManager) handleOutbound(vpnIP uint32, f EncWriter, lighthouseT
 	if err != nil {
 		return
 	}
-	hostinfo.RWMutex.Lock()
-	defer hostinfo.RWMutex.Unlock()
+	hostinfo.Lock()
+	defer hostinfo.Unlock()
 	// If we haven't finished the handshake and we haven't hit max retries, query
 	// lighthouse and then send the handshake packet again.
 	if hostinfo.HandshakeCounter < c.config.retries && !hostinfo.HandshakeComplete {

--- a/hostmap.go
+++ b/hostmap.go
@@ -396,7 +396,7 @@ func (hm *HostMap) PunchList() []*udpAddr {
 	hm.RLock()
 	for _, v := range hm.Hosts {
 		for _, r := range v.Remotes {
-			list = append(list, r.addr)
+			list = append(list, &udpAddr{IP: r.addr.IP, Port: r.addr.Port})
 		}
 		//	if h, ok := hm.Hosts[vpnIp]; ok {
 		//		hm.Hosts[vpnIp].PromoteBest(hm.preferredRanges, false)

--- a/hostmap.go
+++ b/hostmap.go
@@ -444,7 +444,8 @@ func (i *HostInfo) TryPromoteBest(preferredRanges []*net.IPNet, ifce *Interface)
 		i.ForcePromoteBest(preferredRanges)
 		return
 	}
-
+	i.RWMutex.Lock()
+	defer i.RWMutex.Unlock()
 	i.promoteCounter++
 	if i.promoteCounter%PromoteEvery == 0 {
 		// return early if we are already on a preferred remote
@@ -466,9 +467,7 @@ func (i *HostInfo) TryPromoteBest(preferredRanges []*net.IPNet, ifce *Interface)
 		if preferred && !best.Equals(i.remote) {
 			// Try to send a test packet to that host, this should
 			// cause it to detect a roaming event and switch remotes
-			i.RWMutex.Lock()
 			ifce.send(test, testRequest, i.ConnectionState, i, best, []byte(""), make([]byte, 12), make([]byte, mtu))
-			i.RWMutex.Unlock()
 		}
 	}
 }

--- a/hostmap.go
+++ b/hostmap.go
@@ -621,6 +621,8 @@ func (i *HostInfo) GetCert() *cert.NebulaCertificate {
 	return nil
 }
 
+// AddRemote is used to add the given udpAddr as a remote host
+// caller must take care to lock accordingly
 func (i *HostInfo) AddRemote(r udpAddr) *udpAddr {
 	remote := &r
 	//add := true

--- a/hostmap.go
+++ b/hostmap.go
@@ -664,8 +664,8 @@ func (i *HostInfo) logger() *logrus.Entry {
 	}
 
 	li := l.WithField("vpnIp", IntIp(i.hostId))
-	i.ConnectionState.lock.RLock()
-	defer i.ConnectionState.lock.RUnlock()
+	i.ConnectionState.mx.RLock()
+	defer i.ConnectionState.mx.RUnlock()
 	if connState := i.ConnectionState; connState != nil {
 		if peerCert := connState.peerCert; peerCert != nil {
 			li = li.WithField("certName", peerCert.Details.Name)

--- a/hostmap.go
+++ b/hostmap.go
@@ -640,7 +640,9 @@ func (i *HostInfo) AddRemote(r udpAddr) *udpAddr {
 }
 
 func (i *HostInfo) SetRemote(remote udpAddr) {
+	i.Lock()
 	i.remote = i.AddRemote(remote)
+	i.Unlock()
 }
 
 func (i *HostInfo) ClearRemotes() {

--- a/hostmap.go
+++ b/hostmap.go
@@ -585,9 +585,7 @@ func (i *HostInfo) handshakeComplete() {
 	//TODO: HandshakeComplete means send stored packets and ConnectionState.ready means we are ready to send
 	//TODO: if the transition from HandhsakeComplete to ConnectionState.ready happens all within this function they are identical
 
-	i.ConnectionState.queueLock.Lock()
 	i.Lock()
-	defer i.Unlock()
 	i.HandshakeComplete = true
 	//TODO: this should be managed by the handshake state machine to set it based on how many handshake were seen.
 	// Clamping it to 2 gets us out of the woods for now
@@ -599,10 +597,11 @@ func (i *HostInfo) handshakeComplete() {
 		cp.callback(cp.messageType, cp.messageSubType, i, cp.packet, nb, out)
 	}
 	i.packetStore = make([]*cachedPacket, 0)
+	i.ConnectionState.queueLock.Lock()
 	i.ConnectionState.ready = true
 	i.ConnectionState.certState = nil
 	i.ConnectionState.queueLock.Unlock()
-
+	i.Unlock()
 }
 
 func (i *HostInfo) RemoteUDPAddrs() []*udpAddr {

--- a/hostmap.go
+++ b/hostmap.go
@@ -396,7 +396,8 @@ func (hm *HostMap) PunchList() []*udpAddr {
 	hm.RLock()
 	for _, v := range hm.Hosts {
 		for _, r := range v.Remotes {
-			list = append(list, &udpAddr{IP: r.addr.IP, Port: r.addr.Port})
+			uaddr := r.addr.Copy()
+			list = append(list, &uaddr)
 		}
 		//	if h, ok := hm.Hosts[vpnIp]; ok {
 		//		hm.Hosts[vpnIp].PromoteBest(hm.preferredRanges, false)

--- a/hostmap.go
+++ b/hostmap.go
@@ -118,7 +118,9 @@ func (hm *HostMap) GetIndexByVpnIP(vpnIP uint32) (uint32, error) {
 func (hm *HostMap) GetVpnIPByIndex(index uint32) (uint32, error) {
 	hm.RLock()
 	if i, ok := hm.Indexes[index]; ok {
+		i.RLock()
 		vpnIP := i.hostId
+		i.RUnlock()
 		hm.RUnlock()
 		return vpnIP, nil
 	}

--- a/inside.go
+++ b/inside.go
@@ -86,10 +86,11 @@ func (f *Interface) getOrHandshake(vpnIp uint32) *HostInfo {
 		}
 	}
 
-	ci := hostinfo.ConnectionState
 	hostinfo.RLock()
+	ci := hostinfo.ConnectionState
 	ready := ci.IsReady()
 	hostinfo.RUnlock()
+
 	if ready {
 		return hostinfo
 	}

--- a/inside.go
+++ b/inside.go
@@ -45,13 +45,13 @@ func (f *Interface) consumeInsidePacket(packet []byte, fwPacket *FirewallPacket,
 	if !ci.ready {
 		// Because we might be sending stored packets, lock here to stop new things going to
 		// the packet queue.
-		ci.queueLock.Lock()
-		if !ci.ready {
+		ci.mx.RLock()
+		ready := ci.ready
+		ci.mx.RUnlock()
+		if !ready {
 			hostinfo.cachePacket(message, 0, packet, f.sendMessageNow)
-			ci.queueLock.Unlock()
 			return
 		}
-		ci.queueLock.Unlock()
 	}
 
 	dropReason := f.firewall.Drop(packet, *fwPacket, false, hostinfo, trustedCAs)

--- a/inside.go
+++ b/inside.go
@@ -38,8 +38,8 @@ func (f *Interface) consumeInsidePacket(packet []byte, fwPacket *FirewallPacket,
 		}
 		return
 	}
-	hostinfo.RWMutex.Lock()
-	defer hostinfo.RWMutex.Unlock()
+	hostinfo.Lock()
+	defer hostinfo.Unlock()
 	ci := hostinfo.ConnectionState
 
 	if !ci.ready {
@@ -88,9 +88,9 @@ func (f *Interface) getOrHandshake(vpnIp uint32) *HostInfo {
 	}
 
 	ci := hostinfo.ConnectionState
-	hostinfo.RWMutex.RLock()
+	hostinfo.RLock()
 	ready := ci.IsReady()
-	hostinfo.RWMutex.RUnlock()
+	hostinfo.RUnlock()
 	if ready {
 		return hostinfo
 	}

--- a/inside.go
+++ b/inside.go
@@ -38,6 +38,8 @@ func (f *Interface) consumeInsidePacket(packet []byte, fwPacket *FirewallPacket,
 		}
 		return
 	}
+	hostinfo.RWMutex.Lock()
+	defer hostinfo.RWMutex.Unlock()
 	ci := hostinfo.ConnectionState
 
 	if !ci.ready {
@@ -86,11 +88,12 @@ func (f *Interface) getOrHandshake(vpnIp uint32) *HostInfo {
 	}
 
 	ci := hostinfo.ConnectionState
-
+	hostinfo.RWMutex.RLock()
 	if ci != nil && ci.eKey != nil && ci.ready {
+		hostinfo.RWMutex.RUnlock()
 		return hostinfo
 	}
-
+	hostinfo.RWMutex.RUnlock()
 	if ci == nil {
 		// if we don't have a connection state, then send a handshake initiation
 		ci = f.newConnectionState(true, noise.HandshakeIX, []byte{}, 0)

--- a/inside.go
+++ b/inside.go
@@ -101,9 +101,11 @@ func (f *Interface) getOrHandshake(vpnIp uint32) *HostInfo {
 		//ci = f.newConnectionState(true, noise.HandshakeXX, []byte{}, 0)
 		hostinfo.ConnectionState = ci
 	}
-
+	hostinfo.RLock()
+	ready = hostinfo.HandshakeReady
+	hostinfo.RUnlock()
 	// If we have already created the handshake packet, we don't want to call the function at all.
-	if !hostinfo.HandshakeReady {
+	if !ready {
 		ixHandshakeStage0(f, vpnIp, hostinfo)
 		// FIXME: Maybe make XX selectable, but probably not since psk makes it nearly pointless for us.
 		//xx_handshakeStage0(f, ip, hostinfo)

--- a/inside.go
+++ b/inside.go
@@ -89,11 +89,11 @@ func (f *Interface) getOrHandshake(vpnIp uint32) *HostInfo {
 
 	ci := hostinfo.ConnectionState
 	hostinfo.RWMutex.RLock()
-	if ci != nil && ci.eKey != nil && ci.ready {
-		hostinfo.RWMutex.RUnlock()
+	ready := ci.IsReady()
+	hostinfo.RWMutex.RUnlock()
+	if ready {
 		return hostinfo
 	}
-	hostinfo.RWMutex.RUnlock()
 	if ci == nil {
 		// if we don't have a connection state, then send a handshake initiation
 		ci = f.newConnectionState(true, noise.HandshakeIX, []byte{}, 0)

--- a/ssh.go
+++ b/ssh.go
@@ -740,8 +740,12 @@ func sshPrintTunnel(ifce *Interface, fs interface{}, a []string, w sshd.StringWr
 	if args.Pretty {
 		enc.SetIndent("", "    ")
 	}
-
-	return enc.Encode(hostInfo)
+	// need to lock as enc.Encode will call hostInfo.MarshalJSON()
+	// which needs a read lock
+	hostInfo.RLock()
+	err = enc.Encode(hostInfo)
+	hostInfo.RUnlock()
+	return err
 }
 
 func sshReload(fs interface{}, a []string, w sshd.StringWriter) error {


### PR DESCRIPTION
* Fixes race conditions when using nebula on linux hosts although it likely fixes races on other OS as well

TODO:

* ~Double check locking, and try to avoid usage of defer~
* ~Verify lock granularity~
* ~Verify references to `ConnectionState` it seems to be pretty racey~