### PR TITLE
Enable StatsViz And HTTP Pprof

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239
+	github.com/arl/statsviz v0.1.1
 	github.com/armon/go-radix v1.0.0
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/cyberdelia/go-metrics-graphite v0.0.0-20161219230853-39f87cc3b432
@@ -25,6 +26,7 @@ require (
 	github.com/vishvananda/netlink v1.0.1-0.20190522153524-00009fb8606a
 	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df // indirect
 	go.bobheadxi.dev/zapx/zapx v0.6.8
+	go.uber.org/atomic v1.6.0
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/arl/statsviz v0.1.1 h1:BLJ5hIN3Sf1cWtJ6YhMt0WH41+Z6LBmHG8YXJDJpGl8=
+github.com/arl/statsviz v0.1.1/go.mod h1:Dg/DhcWPSzBVk70gVbZWcymzHDkYRhVpeScx5l+Zj7o=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/profiler.go
+++ b/profiler.go
@@ -1,0 +1,91 @@
+package nebula
+
+import (
+	"net/http"
+	"net/http/pprof"
+	"sync"
+	"time"
+
+	"github.com/arl/statsviz"
+	"go.uber.org/atomic"
+)
+
+// profileServer allows serving go runtime debugging
+// and profiling information, and allows serving
+// the statsviz runtime visualizer, as well as net/http/pprof handlers
+type profileServer struct {
+	sync.Mutex
+	start   *sync.Once
+	running *atomic.Bool
+	stop    chan struct{}
+}
+
+func newProfileServer() *profileServer {
+	return &profileServer{
+		start:   &sync.Once{},
+		running: atomic.NewBool(false),
+		stop:    make(chan struct{}),
+	}
+}
+
+func (p *profileServer) Start(addr string, disablePprof, disableStatsViz bool) {
+	if disablePprof && disableStatsViz {
+		l.Error("pprof and statsviz disabled")
+		return
+	}
+	// prevent a panic
+	if p.start == nil {
+		l.Error("statsvizServer object not properly initialized")
+		return
+	}
+	p.Lock()
+	defer p.Unlock()
+	p.start.Do(func() {
+		p.running.Store(true)
+		mux := http.NewServeMux()
+		if !disablePprof {
+			mux.HandleFunc("/debug/pprof/", pprof.Index)
+			mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+			mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+			mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+			mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		}
+		if !disableStatsViz {
+			statsviz.Register(mux)
+		}
+		srv := &http.Server{
+			Addr:    addr,
+			Handler: mux,
+		}
+		go srv.ListenAndServe()
+		go func() {
+			<-p.stop
+			srv.Close()
+			p.running.Store(false)
+		}()
+	})
+}
+
+// used to stop the statsviz server but prepares the struct
+// for being able to startup another server
+func (p *profileServer) Reset() {
+	if !p.running.Load() {
+		return
+	}
+	p.Stop()
+	for {
+		if p.running.Load() {
+			time.Sleep(time.Microsecond * 250)
+			continue
+		}
+		break
+	}
+	p.Lock()
+	defer p.Unlock()
+	p.start = &sync.Once{}
+}
+
+// note: tthis will block, maybe we should do a non-blocking send?
+func (p *profileServer) Stop() {
+	p.stop <- struct{}{}
+}

--- a/ssh.go
+++ b/ssh.go
@@ -15,7 +15,7 @@ import (
 	"go.uber.org/zap"
 )
 
-type sshStatsVizFlags struct {
+type sshProfilerFlags struct {
 	Addr         string
 	DisablePprof bool
 	DisableViz   bool
@@ -175,14 +175,14 @@ func attachCommands(ssh *sshd.SSHServer, hostMap *HostMap, pendingHostMap *HostM
 		ShortDescription: "start the runtime profiler and visualization server",
 		Flags: func() (*flag.FlagSet, interface{}) {
 			fl := flag.NewFlagSet("", flag.ContinueOnError)
-			s := sshStatsVizFlags{}
+			s := sshProfilerFlags{}
 			fl.StringVar(&s.Addr, "address", "0.0.0.0:2345", "address of http server")
 			fl.BoolVar(&s.DisablePprof, "disable-pprof", false, "disables registering net/http/pprof handlers")
 			fl.BoolVar(&s.DisableViz, "disable-visualizer", false, "disables the statsviz runtime visualizer")
 			return fl, &s
 		},
 		Callback: func(fs interface{}, a []string, w sshd.StringWriter) error {
-			flags, ok := fs.(*sshStatsVizFlags)
+			flags, ok := fs.(*sshProfilerFlags)
 			if !ok {
 				//TODO: error
 				return nil

--- a/stats.go
+++ b/stats.go
@@ -6,84 +6,14 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"sync"
 	"time"
 
-	"github.com/arl/statsviz"
 	graphite "github.com/cyberdelia/go-metrics-graphite"
 	mp "github.com/nbrownus/go-metrics-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rcrowley/go-metrics"
-	"go.uber.org/atomic"
 )
-
-// helper object to start up a statsviz server
-// primarily intended for use with the sshd management port
-// however it could potentially be started at node startup as well
-type statsvizServer struct {
-	sync.Mutex
-	start   *sync.Once
-	running *atomic.Bool
-	stop    chan struct{}
-}
-
-func newStatsViz() *statsvizServer {
-	return &statsvizServer{
-		start:   &sync.Once{},
-		running: atomic.NewBool(false),
-		stop:    make(chan struct{}),
-	}
-}
-
-func (s *statsvizServer) Start(addr string) {
-	// prevent a panic
-	if s.start == nil {
-		l.Error("statsvizServer object not properly initialized")
-		return
-	}
-	s.Lock()
-	defer s.Unlock()
-	s.start.Do(func() {
-		s.running.Store(true)
-		mux := http.NewServeMux()
-		statsviz.Register(mux)
-		srv := &http.Server{
-			Addr:    addr,
-			Handler: mux,
-		}
-		go srv.ListenAndServe()
-		go func() {
-			<-s.stop
-			srv.Close()
-			s.running.Store(false)
-		}()
-	})
-}
-
-// used to stop the statsviz server but prepares the struct
-// for being able to startup another server
-func (s *statsvizServer) Reset() {
-	if !s.running.Load() {
-		return
-	}
-	s.Stop()
-	for {
-		if s.running.Load() {
-			time.Sleep(time.Microsecond * 250)
-			continue
-		}
-		break
-	}
-	s.Lock()
-	defer s.Unlock()
-	s.start = &sync.Once{}
-}
-
-// note: tthis will block, maybe we should do a non-blocking send?
-func (s *statsvizServer) Stop() {
-	s.stop <- struct{}{}
-}
 
 func startStats(c *Config, configTest bool) error {
 	mType := c.GetString("stats.type", "")


### PR DESCRIPTION
Adds an sshd command to start a http server that serves [statsviz](https://github.com/arl/statsviz), and `net/http/pprof`, however you can disable either statsviz or pprof.